### PR TITLE
feat(sections): alter posts styling

### DIFF
--- a/content/jobs/Bookmate/Junior.md
+++ b/content/jobs/Bookmate/Junior.md
@@ -4,6 +4,7 @@ title: 'Junior Frontend Developer'
 company: 'Bookmate'
 location: 'Dublin, Ireland'
 range: 'February 2020 - February 2021'
+year: 2020
 url: 'https://www.bookmate.com/'
 tags:
   - React

--- a/content/jobs/Bookmate/Lead.md
+++ b/content/jobs/Bookmate/Lead.md
@@ -4,6 +4,7 @@ title: 'Senior Team Leader'
 company: 'Bookmate'
 location: 'Dublin, Ireland'
 range: 'August 2022 - now'
+year: 2022
 url: 'https://www.bookmate.com/'
 tags:
   - React

--- a/content/jobs/Bookmate/Middle.md
+++ b/content/jobs/Bookmate/Middle.md
@@ -4,6 +4,7 @@ title: 'Middle Frontend Developer'
 company: 'Bookmate'
 location: 'Dublin, Ireland'
 range: 'February 2021 - January 2022'
+year: 2021
 url: 'https://www.bookmate.com/'
 tags:
   - React

--- a/content/jobs/Bookmate/Senior.md
+++ b/content/jobs/Bookmate/Senior.md
@@ -4,6 +4,7 @@ title: 'Senior Frontend Developer'
 company: 'Bookmate'
 location: 'Dublin, Ireland'
 range: 'January 2022 - August 2022'
+year: 2022
 url: 'https://www.bookmate.com/'
 tags:
   - React

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -11,7 +11,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
   const { createPage } = actions;
   const postTemplate = path.resolve(`src/templates/post.js`);
   const tagTemplate = path.resolve('src/templates/tag.js');
-console.log(postTemplate)
+
   const result = await graphql(`{
   postsRemark: allMarkdownRemark(
     filter: {fileAbsolutePath: {regex: "/content/posts/"}}

--- a/src/components/email.js
+++ b/src/components/email.js
@@ -14,9 +14,10 @@ const StyledLinkWrapper = styled.div`
     content: '';
     display: block;
     width: 1px;
-    height: 90px;
+    border: 1px dashed var(--main);
+    height: 124px;
     margin: 0 auto;
-    background-color: var(--light-slate);
+    background-color: var(--text-light);
   }
 
   a {
@@ -27,10 +28,10 @@ const StyledLinkWrapper = styled.div`
     line-height: var(--lg);
     letter-spacing: 0.1em;
     writing-mode: vertical-rl;
-
     &:hover,
     &:focus {
       transform: translateY(-3px);
+      color: var(--highlight);
     }
   }
 `;

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -20,7 +20,7 @@ const StyledSocialLinks = styled.div`
     width: 100%;
     max-width: 270px;
     margin: 0 auto 10px;
-    color: var(--light-slate);
+    color: var(--text-light);
   }
 
   ul {
@@ -30,12 +30,13 @@ const StyledSocialLinks = styled.div`
     list-style: none;
     a {
       padding: 10px;
+      color: var(--accent-dark);
     }
   }
 `;
 
 const StyledCredit = styled.div`
-  color: var(--light-slate);
+  color: var(--text-light);
   font-family: var(--font-main);
   font-size: var(--xxs);
   line-height: 1;

--- a/src/components/menu.js
+++ b/src/components/menu.js
@@ -85,7 +85,6 @@ const StyledHamburgerButton = styled.button`
 
 const StyledSidebar = styled.aside`
   display: none;
-
   @media (max-width: 768px) {
     ${({ theme }) => theme.mixins.flexCentered};
     position: fixed;
@@ -96,8 +95,8 @@ const StyledSidebar = styled.aside`
     width: min(75vw, 400px);
     height: 100vh;
     outline: 0;
-    background-color: var(--light-navy);
-    box-shadow: -10px 0px 30px -15px var(--navy-shadow);
+    background-color: var(--complementary);
+    box-shadow: -10px 0px 30px -15px var(--shadow-main);
     z-index: 9;
     transform: translateX(${props => (props.menuOpen ? 0 : 100)}vw);
     visibility: ${props => (props.menuOpen ? 'visible' : 'hidden')};
@@ -108,7 +107,7 @@ const StyledSidebar = styled.aside`
     ${({ theme }) => theme.mixins.flexBetween};
     width: 100%;
     flex-direction: column;
-    color: var(--light-text);
+    color: var(--text-light);
     font-family: var(--font-main);
     text-align: center;
   }

--- a/src/components/menu.js
+++ b/src/components/menu.js
@@ -44,7 +44,7 @@ const StyledHamburgerButton = styled.button`
     width: var(--hamburger-width);
     height: 2px;
     border-radius: var(--border-radius);
-    background-color: var(--green);
+    background-color: var(--accent);
     transition-duration: 0.22s;
     transition-property: transform;
     transition-delay: ${props => (props.menuOpen ? `0.12s` : `0s`)};
@@ -62,7 +62,7 @@ const StyledHamburgerButton = styled.button`
       width: var(--hamburger-width);
       height: 2px;
       border-radius: 4px;
-      background-color: var(--green);
+      background-color: var(--accent);
       transition-timing-function: ease;
       transition-duration: 0.15s;
       transition-property: transform;
@@ -108,7 +108,7 @@ const StyledSidebar = styled.aside`
     ${({ theme }) => theme.mixins.flexBetween};
     width: 100%;
     flex-direction: column;
-    color: var(--lightest-slate);
+    color: var(--light-text);
     font-family: var(--font-main);
     text-align: center;
   }

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -64,8 +64,7 @@ const StyledNav = styled.nav`
     ${({ theme }) => theme.mixins.flexCentered};
     a {
       color: var(--accent);
-      width: 42px;
-      height: 42px;
+      font-size: 24px;
       &:hover {
         color: var(--highlight);
       }

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -16,7 +16,7 @@ const StyledHeader = styled.header`
   padding: 0px 50px;
   width: 100%;
   height: var(--nav-height);
-  background-color: rgba(10, 25, 47, 0.85);
+  background-color: var(--main);
   filter: none !important;
   pointer-events: auto !important;
   user-select: auto !important;
@@ -37,8 +37,8 @@ const StyledHeader = styled.header`
       css`
         height: var(--nav-scroll-height);
         transform: translateY(0px);
-        background-color: rgba(10, 25, 47, 0.85);
-        box-shadow: 0 10px 30px -10px var(--navy-shadow);
+        background-color: var(--main);
+        box-shadow: 0 10px 30px -10px var(--shadow-main);
       `};
 
     ${props =>
@@ -47,7 +47,7 @@ const StyledHeader = styled.header`
       css`
         height: var(--nav-scroll-height);
         transform: translateY(calc(var(--nav-scroll-height) * -1));
-        box-shadow: 0 10px 30px -10px var(--navy-shadow);
+        box-shadow: 0 10px 30px -10px var(--shadow-main);
       `};
   }
 `;
@@ -56,18 +56,19 @@ const StyledNav = styled.nav`
   ${({ theme }) => theme.mixins.flexBetween};
   position: relative;
   width: 100%;
-  color: var(--light-text);
+  color: var(--text-light);
   font-family: var(--font-main);
   counter-reset: item 0;
   z-index: 12;
-
   .logo {
     ${({ theme }) => theme.mixins.flexCentered};
-
     a {
       color: var(--accent);
       width: 42px;
       height: 42px;
+      &:hover {
+        color: var(--highlight);
+      }
     }
   }
 `;
@@ -94,9 +95,11 @@ const StyledLinks = styled.div`
 
       a {
         padding: 10px;
-
+        &:hover {
+          color: var(--highlight);
+        }
         &:before {
-          content: '0' counter(item) '.';
+          content: '֯֯֯❯' counter(item) '.';
           margin-right: 5px;
           color: var(--accent);
           font-size: var(--xxs);

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -56,7 +56,7 @@ const StyledNav = styled.nav`
   ${({ theme }) => theme.mixins.flexBetween};
   position: relative;
   width: 100%;
-  color: var(--lightest-slate);
+  color: var(--light-text);
   font-family: var(--font-main);
   counter-reset: item 0;
   z-index: 12;
@@ -65,7 +65,7 @@ const StyledNav = styled.nav`
     ${({ theme }) => theme.mixins.flexCentered};
 
     a {
-      color: var(--green);
+      color: var(--accent);
       width: 42px;
       height: 42px;
     }
@@ -98,7 +98,7 @@ const StyledLinks = styled.div`
         &:before {
           content: '0' counter(item) '.';
           margin-right: 5px;
-          color: var(--green);
+          color: var(--accent);
           font-size: var(--xxs);
           text-align: right;
         }

--- a/src/components/sections/about.js
+++ b/src/components/sections/about.js
@@ -126,7 +126,7 @@ const About = () => {
 
   return (
     <StyledAboutSection id="about" ref={revealContainer}>
-      <h2 className="numbered-heading">About Me</h2>
+      <h2 className="subheading">About Me</h2>
       <div className="inner">
         <StyledText>
           <div>
@@ -150,7 +150,7 @@ const About = () => {
               width={500}
               quality={95}
               formats={['AUTO', 'WEBP', 'AVIF']}
-              alt="Headshot"
+              alt="Daria Diachkova photo"
             />
           </div>
         </StyledPic>

--- a/src/components/sections/about.js
+++ b/src/components/sections/about.js
@@ -49,7 +49,7 @@ const StyledText = styled.div`
 const StyledPic = styled.div`
   position: relative;
   max-width: 300px;
-
+  margin-top: -48px;
   @media (max-width: 768px) {
     margin: 50px auto 0;
     width: 70%;
@@ -61,54 +61,20 @@ const StyledPic = styled.div`
     position: relative;
     width: 100%;
     border-radius: var(--border-radius);
-    background-color: var(--accent);
-
     &:hover,
     &:focus {
       outline: 0;
-
-      &:after {
-        top: 15px;
-        left: 15px;
-      }
-
       .img {
         filter: none;
         mix-blend-mode: normal;
       }
     }
-
     .img {
       position: relative;
       border-radius: var(--border-radius);
       mix-blend-mode: multiply;
-      filter: grayscale(100%) contrast(1);
+      filter: grayscale(100%) drop-shadow(8px 8px 12px var(--accent-dark));
       transition: var(--transition);
-    }
-
-    &:before,
-    &:after {
-      content: '';
-      display: block;
-      position: absolute;
-      width: 100%;
-      height: 100%;
-      border-radius: var(--border-radius);
-      transition: var(--transition);
-    }
-
-    &:before {
-      top: 0;
-      left: 0;
-      background-color: var(--main);
-      mix-blend-mode: screen;
-    }
-
-    &:after {
-      border: 2px solid var(--accent);
-      top: 20px;
-      left: 20px;
-      z-index: -1;
     }
   }
 `;

--- a/src/components/sections/about.js
+++ b/src/components/sections/about.js
@@ -100,7 +100,7 @@ const StyledPic = styled.div`
     &:before {
       top: 0;
       left: 0;
-      background-color: var(--navy);
+      background-color: var(--main);
       mix-blend-mode: screen;
     }
 

--- a/src/components/sections/about.js
+++ b/src/components/sections/about.js
@@ -39,7 +39,7 @@ const StyledText = styled.div`
         content: '▹';
         position: absolute;
         left: 0;
-        color: var(--green);
+        color: var(--accent);
         font-size: var(--sm);
         line-height: 12px;
       }
@@ -61,7 +61,7 @@ const StyledPic = styled.div`
     position: relative;
     width: 100%;
     border-radius: var(--border-radius);
-    background-color: var(--green);
+    background-color: var(--accent);
 
     &:hover,
     &:focus {
@@ -105,7 +105,7 @@ const StyledPic = styled.div`
     }
 
     &:after {
-      border: 2px solid var(--green);
+      border: 2px solid var(--accent);
       top: 20px;
       left: 20px;
       z-index: -1;

--- a/src/components/sections/contact.js
+++ b/src/components/sections/contact.js
@@ -16,7 +16,7 @@ const StyledContactSection = styled.section`
   .overline {
     display: block;
     margin-bottom: 20px;
-    color: var(--green);
+    color: var(--accent);
     font-family: var(--font-main);
     font-size: var(--md);
     font-weight: 400;

--- a/src/components/sections/contact.js
+++ b/src/components/sections/contact.js
@@ -52,7 +52,7 @@ const Contact = () => {
 
   return (
     <StyledContactSection id="contact" ref={revealContainer}>
-      <h2 className="numbered-heading overline">What’s Next?</h2>
+      <h2 className="subheading overline">What’s Next?</h2>
       <h2 className="title">Get In Touch</h2>
       <p>
         todo: if I', looking for a job, or just say "hi"

--- a/src/components/sections/featured.js
+++ b/src/components/sections/featured.js
@@ -124,7 +124,7 @@ const StyledProject = styled.li`
   }
 
   .project-title {
-    color: var(--light-text);
+    color: var(--text-light);
     font-size: clamp(24px, 5vw, 28px);
 
     @media (min-width: 768px) {
@@ -157,8 +157,8 @@ const StyledProject = styled.li`
     z-index: 2;
     padding: 25px;
     border-radius: var(--border-radius);
-    background-color: var(--light-navy);
-    color: var(--light-slate);
+    background-color: var(--complementary);
+    color: var(--text-light);
     font-size: var(--lg);
 
     @media (max-width: 768px) {
@@ -192,7 +192,7 @@ const StyledProject = styled.li`
 
     li {
       margin: 0 20px 5px 0;
-      color: var(--light-slate);
+      color: var(--text-light);
       font-family: var(--font-main);
       font-size: var(--xs);
       white-space: nowrap;
@@ -203,7 +203,7 @@ const StyledProject = styled.li`
 
       li {
         margin: 0 10px 5px 0;
-        color: var(--light-text);
+        color: var(--text-light);
       }
     }
   }
@@ -214,7 +214,7 @@ const StyledProject = styled.li`
     position: relative;
     margin-top: 10px;
     margin-left: -10px;
-    color: var(--light-text);
+    color: var(--text-light);
 
     a {
       ${({ theme }) => theme.mixins.flexCentered};
@@ -265,7 +265,7 @@ const StyledProject = styled.li`
         bottom: 0;
         z-index: 3;
         transition: var(--transition);
-        background-color: var(--navy);
+        background-color: var(--main);
         mix-blend-mode: screen;
       }
     }

--- a/src/components/sections/featured.js
+++ b/src/components/sections/featured.js
@@ -323,7 +323,7 @@ const Featured = () => {
 
   return (
     <section id="projects">
-      <h2 className="numbered-heading" ref={revealTitle}>
+      <h2 className="subheading" ref={revealTitle}>
         A Few Things I’ve Built
       </h2>
       <StyledProjectsGrid>

--- a/src/components/sections/featured.js
+++ b/src/components/sections/featured.js
@@ -117,14 +117,14 @@ const StyledProject = styled.li`
 
   .project-overline {
     margin: 10px 0;
-    color: var(--green);
+    color: var(--accent);
     font-family: var(--font-main);
     font-size: var(--xs);
     font-weight: 400;
   }
 
   .project-title {
-    color: var(--lightest-slate);
+    color: var(--light-text);
     font-size: clamp(24px, 5vw, 28px);
 
     @media (min-width: 768px) {
@@ -132,7 +132,7 @@ const StyledProject = styled.li`
     }
 
     @media (max-width: 768px) {
-      color: var(--white);
+      color: white;
 
       a {
         position: static;
@@ -176,7 +176,7 @@ const StyledProject = styled.li`
     }
 
     strong {
-      color: var(--white);
+      color: white;
       font-weight: normal;
     }
   }
@@ -203,7 +203,7 @@ const StyledProject = styled.li`
 
       li {
         margin: 0 10px 5px 0;
-        color: var(--lightest-slate);
+        color: var(--light-text);
       }
     }
   }
@@ -214,7 +214,7 @@ const StyledProject = styled.li`
     position: relative;
     margin-top: 10px;
     margin-left: -10px;
-    color: var(--lightest-slate);
+    color: var(--light-text);
 
     a {
       ${({ theme }) => theme.mixins.flexCentered};
@@ -238,7 +238,7 @@ const StyledProject = styled.li`
     a {
       width: 100%;
       height: 100%;
-      background-color: var(--green);
+      background-color: var(--accent);
       border-radius: var(--border-radius);
       vertical-align: middle;
 

--- a/src/components/sections/featured.js
+++ b/src/components/sections/featured.js
@@ -124,9 +124,12 @@ const StyledProject = styled.li`
   }
 
   .project-title {
-    color: var(--text-light);
+    color: var(--accent);
+    font-family: var(--font-main);
     font-size: clamp(24px, 5vw, 28px);
-
+    > a:hover {
+      color: var(--highlight);
+    }
     @media (min-width: 768px) {
       margin: 0 0 20px;
     }
@@ -238,43 +241,22 @@ const StyledProject = styled.li`
     a {
       width: 100%;
       height: 100%;
-      background-color: var(--accent);
       border-radius: var(--border-radius);
       vertical-align: middle;
-
       &:hover,
       &:focus {
-        background: transparent;
         outline: 0;
-
-        &:before,
         .img {
-          background: transparent;
           filter: none;
+          transition: all 0.2s;
         }
-      }
-
-      &:before {
-        content: '';
-        position: absolute;
-        width: 100%;
-        height: 100%;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        z-index: 3;
-        transition: var(--transition);
-        background-color: var(--main);
-        mix-blend-mode: screen;
       }
     }
 
     .img {
       border-radius: var(--border-radius);
       mix-blend-mode: multiply;
-      filter: grayscale(100%) contrast(1) brightness(90%);
-
+      filter: grayscale(100%) brightness(90%) drop-shadow(-8px -8px 12px var(--accent-dark));
       @media (max-width: 768px) {
         object-fit: cover;
         width: auto;
@@ -337,7 +319,6 @@ const Featured = () => {
               <StyledProject key={i} ref={el => (revealProjects.current[i] = el)}>
                 <div className="project-content">
                   <div>
-                    <p className="project-overline">Featured Project</p>
                     <h3 className="project-title">
                       <a href={url}>{title}</a>
                     </h3>

--- a/src/components/sections/jobs.js
+++ b/src/components/sections/jobs.js
@@ -227,7 +227,7 @@ const Jobs = () => {
 
   return (
     <StyledJobsSection id="jobs" ref={revealContainer}>
-      <h2 className="numbered-heading">Where I’ve Worked</h2>
+      <h2 className="subheading">Where I’ve Worked</h2>
 
       <div className="inner">
         <StyledTabList role="tablist" aria-label="Job tabs" onKeyDown={e => onKeyDown(e)}>

--- a/src/components/sections/jobs.js
+++ b/src/components/sections/jobs.js
@@ -8,9 +8,10 @@ import isServer from '@constants/server-helper';
 import { usePrefersReducedMotion } from '@hooks';
 
 const StyledJobsSection = styled.section`
-  max-width: 700px;
   .inner {
     display: flex;
+    max-width: 800px;
+    margin: auto;
     @media (max-width: 600px) {
       display: block;
     }
@@ -27,7 +28,6 @@ const StyledTabList = styled.div`
   padding: 0;
   margin: 0;
   list-style: none;
-
   @media (max-width: 600px) {
     display: flex;
     overflow-x: auto;
@@ -73,7 +73,7 @@ const StyledTabButton = styled.button`
   height: var(--tab-height);
   padding: 0 20px 2px;
   border-left: 2px solid var(--accent-tint);
-  background-color: transparent;
+  background-color: ${({ isActive }) => (isActive ? 'var(--complementary)' : 'transparent')};;
   color: ${({ isActive }) => (isActive ? 'var(--accent)' : 'var(--text-light)')};
   font-family: var(--font-main);
   font-size: var(--xs);
@@ -91,10 +91,6 @@ const StyledTabButton = styled.button`
     border-bottom: 2px solid var(--accent-tint);
     text-align: center;
   }
-  &:hover,
-  &:focus {
-    background-color: var(--complementary);
-  }
 `;
 
 const StyledHighlight = styled.div`
@@ -109,7 +105,6 @@ const StyledHighlight = styled.div`
   transform: translateY(calc(${({ activeTabId }) => activeTabId} * var(--tab-height)));
   transition: transform 0.25s cubic-bezier(0.645, 0.045, 0.355, 1);
   transition-delay: 0.1s;
-
   @media (max-width: 600px) {
     top: auto;
     bottom: 0;
@@ -127,8 +122,7 @@ const StyledHighlight = styled.div`
 const StyledTabPanels = styled.div`
   position: relative;
   width: 100%;
-  margin-left: 20px;
-
+  margin-left: 48px;
   @media (max-width: 600px) {
     margin-left: 0;
   }
@@ -138,17 +132,14 @@ const StyledTabPanel = styled.div`
   width: 100%;
   height: auto;
   padding: 10px 5px;
-
   ul {
     ${({ theme }) => theme.mixins.listStyled};
   }
-
   h3 {
     margin-bottom: 2px;
     font-size: var(--xxl);
     font-weight: 500;
     line-height: 1.3;
-
     .company {
       color: var(--accent);
     }
@@ -229,7 +220,7 @@ const Jobs = () => {
 
   return (
     <StyledJobsSection id="jobs" ref={revealContainer}>
-      <h2 className="subheading">Where I’ve Worked</h2>
+      <h2 className="subheading centered">Where I’ve Worked</h2>
       <div className="inner">
         <StyledTabList role="tablist" aria-label="Job tabs" onKeyDown={e => onKeyDown(e)}>
           {jobsData &&
@@ -253,7 +244,6 @@ const Jobs = () => {
             })}
           <StyledHighlight activeTabId={activeTabId} />
         </StyledTabList>
-
         <StyledTabPanels>
           {jobsData &&
             jobsData.map(({ node }, i) => {
@@ -272,7 +262,7 @@ const Jobs = () => {
                     <h3>
                       <span>{title}</span>
                       <span className="company">
-                        &nbsp;@&nbsp;
+                        &nbsp;at&nbsp;
                         <a href={url} className="inline-link">
                           {company}
                         </a>

--- a/src/components/sections/jobs.js
+++ b/src/components/sections/jobs.js
@@ -70,9 +70,9 @@ const StyledTabButton = styled.button`
   width: 100%;
   height: var(--tab-height);
   padding: 0 20px 2px;
-  border-left: 2px solid var(--lightest-navy);
+  border-left: 2px solid var(--accent-tint);
   background-color: transparent;
-  color: ${({ isActive }) => (isActive ? 'var(--accent)' : 'var(--slate)')};
+  color: ${({ isActive }) => (isActive ? 'var(--accent)' : 'var(--text-light)')};
   font-family: var(--font-main);
   font-size: var(--xs);
   text-align: left;
@@ -86,13 +86,13 @@ const StyledTabButton = styled.button`
     min-width: 120px;
     padding: 0 15px;
     border-left: 0;
-    border-bottom: 2px solid var(--lightest-navy);
+    border-bottom: 2px solid var(--accent-tint);
     text-align: center;
   }
 
   &:hover,
   &:focus {
-    background-color: var(--light-navy);
+    background-color: var(--complementary);
   }
 `;
 
@@ -155,7 +155,7 @@ const StyledTabPanel = styled.div`
 
   .range {
     margin-bottom: 25px;
-    color: var(--light-slate);
+    color: var(--text-light);
     font-family: var(--font-main);
     font-size: var(--xs);
   }

--- a/src/components/sections/jobs.js
+++ b/src/components/sections/jobs.js
@@ -72,7 +72,7 @@ const StyledTabButton = styled.button`
   padding: 0 20px 2px;
   border-left: 2px solid var(--lightest-navy);
   background-color: transparent;
-  color: ${({ isActive }) => (isActive ? 'var(--green)' : 'var(--slate)')};
+  color: ${({ isActive }) => (isActive ? 'var(--accent)' : 'var(--slate)')};
   font-family: var(--font-main);
   font-size: var(--xs);
   text-align: left;
@@ -104,7 +104,7 @@ const StyledHighlight = styled.div`
   width: 2px;
   height: var(--tab-height);
   border-radius: var(--border-radius);
-  background: var(--green);
+  background: var(--accent);
   transform: translateY(calc(${({ activeTabId }) => activeTabId} * var(--tab-height)));
   transition: transform 0.25s cubic-bezier(0.645, 0.045, 0.355, 1);
   transition-delay: 0.1s;
@@ -149,7 +149,7 @@ const StyledTabPanel = styled.div`
     line-height: 1.3;
 
     .company {
-      color: var(--green);
+      color: var(--accent);
     }
   }
 

--- a/src/components/sections/jobs.js
+++ b/src/components/sections/jobs.js
@@ -9,7 +9,6 @@ import { usePrefersReducedMotion } from '@hooks';
 
 const StyledJobsSection = styled.section`
   max-width: 700px;
-
   .inner {
     display: flex;
     @media (max-width: 600px) {
@@ -61,6 +60,9 @@ const StyledTabList = styled.div`
       }
     }
   }
+  .job-year-label {
+    margin-right: 8px;
+  }
 `;
 
 const StyledTabButton = styled.button`
@@ -89,7 +91,6 @@ const StyledTabButton = styled.button`
     border-bottom: 2px solid var(--accent-tint);
     text-align: center;
   }
-
   &:hover,
   &:focus {
     background-color: var(--complementary);
@@ -175,6 +176,7 @@ const Jobs = () => {
           location
           range
           url
+          year
         }
         html
       }
@@ -228,12 +230,11 @@ const Jobs = () => {
   return (
     <StyledJobsSection id="jobs" ref={revealContainer}>
       <h2 className="subheading">Where I’ve Worked</h2>
-
       <div className="inner">
         <StyledTabList role="tablist" aria-label="Job tabs" onKeyDown={e => onKeyDown(e)}>
           {jobsData &&
             jobsData.map(({ node }, i) => {
-              const { title } = node.frontmatter;
+              const { title, year } = node.frontmatter;
               return (
                 <StyledTabButton
                   key={i}
@@ -245,6 +246,7 @@ const Jobs = () => {
                   tabIndex={activeTabId === i ? '0' : '-1'}
                   aria-selected={activeTabId === i ? true : false}
                   aria-controls={`panel-${i}`}>
+                  <span className="job-year-label">{year}:</span>
                   <span>{title}</span>
                 </StyledTabButton>
               );

--- a/src/components/sections/me.js
+++ b/src/components/sections/me.js
@@ -34,15 +34,16 @@ const StyledMeSection = styled.section`
     color: var(--text-light);
     line-height: 0.9;
   }
-
   p {
-    margin: 20px 0 0;
     max-width: 540px;
   }
-
   .email-link {
     ${({ theme }) => theme.mixins.buttonBig};
     margin-top: 50px;
+  }
+  .heading-caption {
+    font-family: var(--font-main);
+    font-size: 18px;
   }
 `;
 
@@ -57,29 +58,24 @@ const Me = () => {
     return () => clearTimeout(timeout);
   }, [prefersReducedMotion]);
 
-  const one = <h1>Hi, my name is</h1>;
-  const two = <h2 className="big-heading">Daria Diachkova.</h2>;
-  const three = <h3 className="big-heading">todo: what i do</h3>;
-  const four = (
-    <p>
-      todo: about me
-    </p>
-  );
-
-  const items = [one, two, three, four];
+  const introItems = [
+      <h1 className="heading-caption">Hi, my name is</h1>,
+      <h2 className="heading-main">Daria Diachkova.</h2>,
+      <h3 className="subheading-main">I build things for the web.</h3>,
+  ]
 
   return (
     <StyledMeSection>
       {prefersReducedMotion ? (
         <>
-          {items.map((item, i) => (
+          {introItems.map((item, i) => (
             <div key={i}>{item}</div>
           ))}
         </>
       ) : (
         <TransitionGroup component={null}>
           {isMounted &&
-            items.map((item, i) => (
+            introItems.map((item, i) => (
               <CSSTransition key={i} classNames="fadeup" timeout={LOAD_DEPLAY}>
                 <div style={{ transitionDelay: `${i + 1}00ms` }}>{item}</div>
               </CSSTransition>

--- a/src/components/sections/me.js
+++ b/src/components/sections/me.js
@@ -19,7 +19,7 @@ const StyledMeSection = styled.section`
 
   h1 {
     margin: 0 0 30px 4px;
-    color: var(--green);
+    color: var(--accent);
     font-family: var(--font-main);
     font-size: clamp(var(--sm), 5vw, var(--md));
     font-weight: 400;

--- a/src/components/sections/me.js
+++ b/src/components/sections/me.js
@@ -14,7 +14,7 @@ const StyledMeSection = styled.section`
 
   @media (max-height: 700px) and (min-width: 700px), (max-width: 360px) {
     height: auto;
-    padding-top: var(--nav-height);
+    padding-top: var(--nav-height) / 2;
   }
 
   h1 {
@@ -27,15 +27,6 @@ const StyledMeSection = styled.section`
     @media (max-width: 480px) {
       margin: 0 0 20px 2px;
     }
-  }
-
-  h3 {
-    margin-top: 5px;
-    color: var(--text-light);
-    line-height: 0.9;
-  }
-  p {
-    max-width: 540px;
   }
   .email-link {
     ${({ theme }) => theme.mixins.buttonBig};

--- a/src/components/sections/me.js
+++ b/src/components/sections/me.js
@@ -31,7 +31,7 @@ const StyledMeSection = styled.section`
 
   h3 {
     margin-top: 5px;
-    color: var(--slate);
+    color: var(--text-light);
     line-height: 0.9;
   }
 

--- a/src/components/sections/posts.js
+++ b/src/components/sections/posts.js
@@ -71,7 +71,7 @@ const StyledPost = styled.li`
     height: 100%;
     padding: 2rem 1.75rem;
     border-radius: var(--border-radius);
-    background-color: var(--light-navy);
+    background-color: var(--complementary);
     transition: var(--transition);
     overflow: auto;
   }
@@ -88,7 +88,7 @@ const StyledPost = styled.li`
       display: flex;
       align-items: center;
       margin-right: -10px;
-      color: var(--light-slate);
+      color: var(--text-light);
 
       a {
         ${({ theme }) => theme.mixins.flexCentered};
@@ -99,7 +99,7 @@ const StyledPost = styled.li`
 
   .project-title {
     margin: 0 0 10px;
-    color: var(--light-text);
+    color: var(--text-light);
     font-size: var(--xxl);
 
     a {
@@ -119,7 +119,7 @@ const StyledPost = styled.li`
   }
 
   .project-description {
-    color: var(--light-slate);
+    color: var(--text-light);
     font-size: 17px;
 
     a {

--- a/src/components/sections/posts.js
+++ b/src/components/sections/posts.js
@@ -81,7 +81,7 @@ const StyledPost = styled.li`
     margin-bottom: 35px;
 
     .folder {
-      color: var(--green);
+      color: var(--accent);
     }
 
     .project-links {
@@ -99,7 +99,7 @@ const StyledPost = styled.li`
 
   .project-title {
     margin: 0 0 10px;
-    color: var(--lightest-slate);
+    color: var(--light-text);
     font-size: var(--xxl);
 
     a {
@@ -159,8 +159,8 @@ const Posts = () => {
         frontmatter {
           title
           tags
-          github
-          url
+          slug
+          description
         }
         html
       }
@@ -187,9 +187,9 @@ const Posts = () => {
   const firstSix = posts.slice(0, GRID_LIMIT);
   const postsToShow = showMore ? posts : firstSix;
 
-  const projectInner = node => {
-    const { frontmatter, html } = node;
-    const { github, url, title, tags } = frontmatter;
+  const postInner = node => {
+    const { frontmatter } = node;
+    const { slug, title, description, tags } = frontmatter;
 
     return (
       <div className="project-inner">
@@ -199,14 +199,9 @@ const Posts = () => {
               <Icon name="Folder" />
             </div>
             <div className="project-links">
-              {github && (
-                <a href={github} aria-label="GitHub Link" target="_blank" rel="noreferrer">
-                  <Icon name="GitHub" />
-                </a>
-              )}
-              {url && (
+              {slug && (
                 <a
-                  href={url}
+                  href={slug}
                   aria-label="url Link"
                   className="url"
                   target="_blank"
@@ -216,16 +211,13 @@ const Posts = () => {
               )}
             </div>
           </div>
-
           <h3 className="project-title">
-            <a href={url} target="_blank" rel="noreferrer">
+            <a href={slug} target="_blank" rel="noreferrer">
               {title}
             </a>
           </h3>
-
-          <div className="project-description" dangerouslySetInnerHTML={{ __html: html }} />
+          <div className="project-description">{description}</div>
         </header>
-
         <footer>
           {tags && (
             <ul className="project-tags-list">
@@ -250,7 +242,7 @@ const Posts = () => {
           <>
             {postsToShow &&
               postsToShow.map(({ node }, i) => (
-                <StyledPost key={i}>{projectInner(node)}</StyledPost>
+                <StyledPost key={i}>{postInner(node)}</StyledPost>
               ))}
           </>
         ) : (
@@ -268,7 +260,7 @@ const Posts = () => {
                     style={{
                       transitionDelay: `${i >= GRID_LIMIT ? (i - GRID_LIMIT) * 100 : 0}ms`,
                     }}>
-                    {projectInner(node)}
+                    {postInner(node)}
                   </StyledPost>
                 </CSSTransition>
               ))}

--- a/src/components/sections/projects.js
+++ b/src/components/sections/projects.js
@@ -71,7 +71,7 @@ const StyledProject = styled.li`
     height: 100%;
     padding: 2rem 1.75rem;
     border-radius: var(--border-radius);
-    background-color: var(--light-navy);
+    background-color: var(--complementary);
     transition: var(--transition);
     overflow: auto;
   }
@@ -88,7 +88,7 @@ const StyledProject = styled.li`
       display: flex;
       align-items: center;
       margin-right: -10px;
-      color: var(--light-slate);
+      color: var(--text-light);
 
       a {
         ${({ theme }) => theme.mixins.flexCentered};
@@ -99,7 +99,7 @@ const StyledProject = styled.li`
 
   .project-title {
     margin: 0 0 10px;
-    color: var(--light-text);
+    color: var(--text-light);
     font-size: var(--xxl);
 
     a {
@@ -119,7 +119,7 @@ const StyledProject = styled.li`
   }
 
   .project-description {
-    color: var(--light-slate);
+    color: var(--text-light);
     font-size: 17px;
 
     a {

--- a/src/components/sections/projects.js
+++ b/src/components/sections/projects.js
@@ -81,7 +81,7 @@ const StyledProject = styled.li`
     margin-bottom: 35px;
 
     .folder {
-      color: var(--green);
+      color: var(--accent);
     }
 
     .project-links {
@@ -99,7 +99,7 @@ const StyledProject = styled.li`
 
   .project-title {
     margin: 0 0 10px;
-    color: var(--lightest-slate);
+    color: var(--light-text);
     font-size: var(--xxl);
 
     a {

--- a/src/components/side.js
+++ b/src/components/side.js
@@ -12,7 +12,7 @@ const StyledSideElement = styled.div`
   left: ${props => (props.orientation === 'left' ? '40px' : 'auto')};
   right: ${props => (props.orientation === 'left' ? 'auto' : '40px')};
   z-index: 10;
-  color: var(--light-slate);
+  color: var(--text-light);
   @media (max-width: 1080px) {
     left: ${props => (props.orientation === 'left' ? '20px' : 'auto')};
     right: ${props => (props.orientation === 'left' ? 'auto' : '20px')};

--- a/src/components/social.js
+++ b/src/components/social.js
@@ -12,27 +12,26 @@ const StyledSocialList = styled.ul`
   margin: 0;
   padding: 0;
   list-style: none;
-
   &:after {
     content: '';
     display: block;
     width: 1px;
-    height: 90px;
+    height: 42px;
     margin: 0 auto;
-    background-color: var(--light-slate);
+    background-color: var(--accent);
+    border: 1px dashed var(--main);
   }
-
   li {
     &:last-of-type {
       margin-bottom: 20px;
     }
-
     a {
       padding: 10px;
-
+      color: var(--accent-dark);
       &:hover,
       &:focus {
         transform: translateY(-3px);
+        color: var(--highlight);
       }
     }
   }

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -13,7 +13,7 @@ const StyledMainContainer = styled.main`
   flex-direction: column;
 `;
 const StyledTitle = styled.h1`
-  color: var(--green);
+  color: var(--accent);
   font-family: var(--font-main);
   font-size: clamp(100px, 25vw, 200px);
   line-height: 1;

--- a/src/pages/archive.js
+++ b/src/pages/archive.js
@@ -29,7 +29,7 @@ const StyledTableContainer = styled.div`
     tbody tr {
       &:hover,
       &:focus {
-        background-color: var(--light-navy);
+        background-color: var(--complementary);
       }
     }
 
@@ -79,7 +79,7 @@ const StyledTableContainer = styled.div`
       &.title {
         padding-top: 15px;
         padding-right: 20px;
-        color: var(--light-text);
+        color: var(--text-light);
         font-size: var(--xl);
         font-weight: 600;
         line-height: 1.25;

--- a/src/pages/archive.js
+++ b/src/pages/archive.js
@@ -79,7 +79,7 @@ const StyledTableContainer = styled.div`
       &.title {
         padding-top: 15px;
         padding-right: 20px;
-        color: var(--lightest-slate);
+        color: var(--light-text);
         font-size: var(--xl);
         font-weight: 600;
         line-height: 1.25;

--- a/src/pages/archive.js
+++ b/src/pages/archive.js
@@ -144,7 +144,7 @@ const ArchivePage = ({ location, data }) => {
 
       <main>
         <header ref={revealTitle}>
-          <h1 className="big-heading">Archive</h1>
+          <h1 className="heading-main">Archive</h1>
           <p className="subtitle">A big list of things I’ve worked on</p>
         </header>
 

--- a/src/pages/posts/index.js
+++ b/src/pages/posts/index.js
@@ -68,7 +68,7 @@ const StyledPost = styled.li`
     padding: 2rem 1.75rem;
     border-radius: var(--border-radius);
     transition: var(--transition);
-    background-color: var(--light-navy);
+    background-color: var(--complementary);
 
     header,
     a {
@@ -85,7 +85,7 @@ const StyledPost = styled.li`
 
   .post__title {
     margin: 0 0 10px;
-    color: var(--light-text);
+    color: var(--text-light);
     font-size: var(--xxl);
 
     a {
@@ -105,12 +105,12 @@ const StyledPost = styled.li`
   }
 
   .post__desc {
-    color: var(--light-slate);
+    color: var(--text-light);
     font-size: 17px;
   }
 
   .post__date {
-    color: var(--light-slate);
+    color: var(--text-light);
     font-family: var(--font-main);
     font-size: var(--xxs);
     text-transform: uppercase;

--- a/src/pages/posts/index.js
+++ b/src/pages/posts/index.js
@@ -143,15 +143,13 @@ const PostsPage = ({ location, data }) => {
   return (
     <Layout location={location}>
       <Helmet title="Posts" />
-
       <StyledMainContainer>
         <header>
-          <h1 className="big-heading">Posts</h1>
+          <h1 className="heading-main">Posts</h1>
           <p className="subtitle">
             a collection
           </p>
         </header>
-
         <StyledGrid>
           {posts.length > 0 &&
             posts.map(({ node }, i) => {

--- a/src/pages/posts/index.js
+++ b/src/pages/posts/index.js
@@ -78,14 +78,14 @@ const StyledPost = styled.li`
 
   .post__icon {
     ${({ theme }) => theme.mixins.flexBetween};
-    color: var(--green);
+    color: var(--accent);
     margin-bottom: 30px;
     margin-left: -5px;
   }
 
   .post__title {
     margin: 0 0 10px;
-    color: var(--lightest-slate);
+    color: var(--light-text);
     font-size: var(--xxl);
 
     a {
@@ -125,7 +125,7 @@ const StyledPost = styled.li`
     list-style: none;
 
     li {
-      color: var(--green);
+      color: var(--accent);
       font-family: var(--font-main);
       font-size: var(--xxs);
       line-height: 1.75;

--- a/src/pages/posts/tags.js
+++ b/src/pages/posts/tags.js
@@ -13,16 +13,16 @@ const StyledTagsContainer = styled.main`
     margin-bottom: 50px;
   }
   ul {
-    color: var(--light-slate);
+    color: var(--text-light);
 
     li {
       font-size: var(--xxl);
 
       a {
-        color: var(--light-slate);
+        color: var(--text-light);
 
         .count {
-          color: var(--slate);
+          color: var(--text-light);
           font-family: var(--font-main);
           font-size: var(--md);
         }

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -20,8 +20,8 @@ const GlobalStyle = createGlobalStyle`
   }
 
   ::selection {
-    background-color: var(--lightest-navy);
-    color: var(--light-text);
+    background-color: var(--accent-tint);
+    color: var(--text-light);
   }
 
   /* Provide basic, default focus styles.*/
@@ -42,17 +42,17 @@ const GlobalStyle = createGlobalStyle`
 
   html {
     scrollbar-width: thin;
-    scrollbar-color: var(--dark-slate) var(--navy);
+    scrollbar-color: var(--dark-complementary) var(--main);
   }
   ::-webkit-scrollbar {
     width: 12px;
   }
   ::-webkit-scrollbar-track {
-    background: var(--navy);
+    background: var(--main);
   }
   ::-webkit-scrollbar-thumb {
-    background-color: var(--dark-slate);
-    border: 3px solid var(--navy);
+    background-color: var(--dark-complementary);
+    border: 3px solid var(--main);
     border-radius: 10px;
   }
 
@@ -63,8 +63,8 @@ const GlobalStyle = createGlobalStyle`
     overflow-x: hidden;
     -moz-osx-font-smoothing: grayscale;
     -webkit-font-smoothing: antialiased;
-    background-color: var(--navy);
-    color: var(--slate);
+    background-color: var(--main);
+    color: var(--text-light);
     font-family: var(--font-accent);
     font-size: var(--xl);
     line-height: 1.3;
@@ -154,7 +154,7 @@ const GlobalStyle = createGlobalStyle`
   h6 {
     margin: 0 0 10px 0;
     font-weight: 600;
-    color: var(--light-text);
+    color: var(--text-light);
     line-height: 1.1;
   }
 
@@ -181,7 +181,7 @@ const GlobalStyle = createGlobalStyle`
       position: relative;
       bottom: 4px;
       counter-increment: section;
-      content: '0' counter(section) '.';
+      content: counter(section) '.';
       margin-right: 10px;
       color: var(--accent);
       font-family: var(--font-main);
@@ -202,7 +202,7 @@ const GlobalStyle = createGlobalStyle`
       width: 300px;
       height: 1px;
       margin-left: 20px;
-      background-color: var(--lightest-navy);
+      background-color: var(--accent-tint);
 
       @media (max-width: 1080px) {
         width: 200px;
@@ -280,7 +280,7 @@ const GlobalStyle = createGlobalStyle`
     }
 
     & > code {
-      background-color: var(--light-navy);
+      background-color: var(--complementary);
       color: white;
       font-size: var(--sm);
       border-radius: var(--border-radius);
@@ -323,7 +323,7 @@ const GlobalStyle = createGlobalStyle`
   }
 
   hr {
-    background-color: var(--lightest-navy);
+    background-color: var(--accent-tint);
     height: 1px;
     border-width: 0px;
     border-style: initial;
@@ -350,7 +350,7 @@ const GlobalStyle = createGlobalStyle`
     &:focus,
     &:active {
       background-color: var(--accent);
-      color: var(--navy);
+      color: var(--main);
       top: 0;
       left: 0;
       width: auto;

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -158,9 +158,15 @@ const GlobalStyle = createGlobalStyle`
     line-height: 1.1;
   }
 
-  .big-heading {
+  .heading-main {
     margin: 0;
     font-size: clamp(40px, 8vw, 80px);
+  }
+
+  .subheading-main {
+    margin: 24px 0;
+    font-size: clamp(32px, 6vw, 58px);
+    font-family: var(--font-main);
   }
 
   .medium-heading {

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -21,12 +21,12 @@ const GlobalStyle = createGlobalStyle`
 
   ::selection {
     background-color: var(--lightest-navy);
-    color: var(--lightest-slate);
+    color: var(--light-text);
   }
 
   /* Provide basic, default focus styles.*/
   :focus {
-    outline: 2px dashed var(--green);
+    outline: 2px dashed var(--accent);
     outline-offset: 3px;
   }
 
@@ -36,7 +36,7 @@ const GlobalStyle = createGlobalStyle`
   }
 
   :focus-visible {
-    outline: 2px dashed var(--green);
+    outline: 2px dashed var(--accent);
     outline-offset: 3px;
   }
 
@@ -154,7 +154,7 @@ const GlobalStyle = createGlobalStyle`
   h6 {
     margin: 0 0 10px 0;
     font-weight: 600;
-    color: var(--lightest-slate);
+    color: var(--light-text);
     line-height: 1.1;
   }
 
@@ -183,7 +183,7 @@ const GlobalStyle = createGlobalStyle`
       counter-increment: section;
       content: '0' counter(section) '.';
       margin-right: 10px;
-      color: var(--green);
+      color: var(--accent);
       font-family: var(--font-main);
       font-size: clamp(var(--md), 3vw, var(--xl));
       font-weight: 400;
@@ -238,7 +238,7 @@ const GlobalStyle = createGlobalStyle`
 
     &:hover,
     &:focus {
-      color: var(--green);
+      color: var(--accent);
     }
 
     &.inline-link {
@@ -281,7 +281,7 @@ const GlobalStyle = createGlobalStyle`
 
     & > code {
       background-color: var(--light-navy);
-      color: var(--white);
+      color: white;
       font-size: var(--sm);
       border-radius: var(--border-radius);
       padding: 0.3em 0.5em;
@@ -302,14 +302,14 @@ const GlobalStyle = createGlobalStyle`
           content: '▹';
           position: absolute;
           left: 0;
-          color: var(--green);
+          color: var(--accent);
         }
       }
     }
   }
 
   blockquote {
-    border-left-color: var(--green);
+    border-left-color: var(--accent);
     border-left-style: solid;
     border-left-width: 1px;
     margin-left: 0px;
@@ -349,7 +349,7 @@ const GlobalStyle = createGlobalStyle`
 
     &:focus,
     &:active {
-      background-color: var(--green);
+      background-color: var(--accent);
       color: var(--navy);
       top: 0;
       left: 0;
@@ -361,18 +361,18 @@ const GlobalStyle = createGlobalStyle`
   }
 
   #logo {
-    color: var(--green);
+    color: var(--accent);
   }
 
   .overline {
-    color: var(--green);
+    color: var(--accent);
     font-family: var(--font-main);
     font-size: var(--md);
     font-weight: 400;
   }
 
   .subtitle {
-    color: var(--green);
+    color: var(--accent);
     margin: 0 0 20px 0;
     font-size: var(--md);
     font-family: var(--font-main);
@@ -395,7 +395,7 @@ const GlobalStyle = createGlobalStyle`
     display: flex;
     align-items: center;
     margin-bottom: 50px;
-    color: var(--green);
+    color: var(--accent);
 
     .arrow {
       display: block;

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -176,7 +176,8 @@ const GlobalStyle = createGlobalStyle`
     font-size: clamp(40px, 8vw, 60px);
   }
 
-  .numbered-heading {
+  .subheading {
+    font-family: var(--font-main);
     display: flex;
     align-items: center;
     position: relative;
@@ -189,37 +190,17 @@ const GlobalStyle = createGlobalStyle`
       position: relative;
       bottom: 4px;
       counter-increment: section;
-      content: counter(section) '.';
+      content: '✰' counter(section) '.';
       margin-right: 10px;
       color: var(--accent);
       font-family: var(--font-main);
       font-size: clamp(var(--md), 3vw, var(--xl));
       font-weight: 400;
+      text-decoration: underline;
 
       @media (max-width: 480px) {
         margin-bottom: -3px;
         margin-right: 5px;
-      }
-    }
-
-    &:after {
-      content: '';
-      display: block;
-      position: relative;
-      top: -5px;
-      width: 300px;
-      height: 1px;
-      margin-left: 20px;
-      background-color: var(--accent-tint);
-
-      @media (max-width: 1080px) {
-        width: 200px;
-      }
-      @media (max-width: 768px) {
-        width: 100%;
-      }
-      @media (max-width: 600px) {
-        margin-left: 10px;
       }
     }
   }

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -164,9 +164,11 @@ const GlobalStyle = createGlobalStyle`
   }
 
   .subheading-main {
-    margin: 24px 0;
-    font-size: clamp(32px, 6vw, 58px);
+    margin: 8px 0;
+    font-size: clamp(32px, 6vw, 48px);
     font-family: var(--font-main);
+    color: var(--accent);
+    filter: drop-shadow(2px 4px 6px var(--accent-dark));
   }
 
   .medium-heading {

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -277,6 +277,10 @@ const GlobalStyle = createGlobalStyle`
     }
   }
 
+  .centered {
+    justify-content: center;
+  }
+
   ul {
     &.fancy-list {
       padding: 0;

--- a/src/styles/mixins.js
+++ b/src/styles/mixins.js
@@ -134,12 +134,12 @@ const mixins = {
   `,
 
   boxShadow: css`
-    box-shadow: 0 10px 30px -15px var(--navy-shadow);
+    box-shadow: 0 10px 30px -15px var(--shadow-main);
     transition: var(--transition);
 
     &:hover,
     &:focus {
-      box-shadow: 0 20px 30px -15px var(--navy-shadow);
+      box-shadow: 0 20px 30px -15px var(--shadow-main);
     }
   `,
 

--- a/src/styles/mixins.js
+++ b/src/styles/mixins.js
@@ -1,9 +1,9 @@
 import { css } from 'styled-components';
 
 const button = css`
-  color: var(--green);
+  color: var(--accent);
   background-color: transparent;
-  border: 1px solid var(--green);
+  border: 1px solid var(--accent);
   border-radius: var(--border-radius);
   font-size: var(--xs);
   font-family: var(--font-main);
@@ -16,7 +16,7 @@ const button = css`
   &:hover,
   &:focus,
   &:active {
-    background-color: var(--green-tint);
+    background-color: var(--accent-tint);
     outline: none;
   }
   &:after {
@@ -47,7 +47,7 @@ const mixins = {
     &:hover,
     &:active,
     &:focus {
-      color: var(--green);
+      color: var(--accent);
       outline: 0;
     }
   `,
@@ -58,17 +58,17 @@ const mixins = {
     text-decoration-skip-ink: auto;
     position: relative;
     transition: var(--transition);
-    color: var(--green);
+    color: var(--accent);
     &:hover,
     &:focus,
     &:active {
-      color: var(--green);
+      color: var(--accent);
       outline: 0;
       &:after {
         width: 100%;
       }
       & > * {
-        color: var(--green) !important;
+        color: var(--accent) !important;
         transition: var(--transition);
       }
     }
@@ -79,7 +79,7 @@ const mixins = {
       height: 1px;
       position: relative;
       bottom: 0.37em;
-      background-color: var(--green);
+      background-color: var(--accent);
       transition: var(--transition);
       opacity: 0.5;
     }
@@ -88,9 +88,9 @@ const mixins = {
   button,
 
   buttonSmall: css`
-    color: var(--green);
+    color: var(--accent);
     background-color: transparent;
-    border: 1px solid var(--green);
+    border: 1px solid var(--accent);
     border-radius: var(--border-radius);
     padding: 0.75rem 1rem;
     font-size: var(--xs);
@@ -102,7 +102,7 @@ const mixins = {
     &:hover,
     &:focus,
     &:active {
-      background-color: var(--green-tint);
+      background-color: var(--accent-tint);
       outline: none;
     }
     &:after {
@@ -111,9 +111,9 @@ const mixins = {
   `,
 
   buttonBig: css`
-    color: var(--green);
+    color: var(--accent);
     background-color: transparent;
-    border: 1px solid var(--green);
+    border: 1px solid var(--accent);
     border-radius: var(--border-radius);
     padding: 1.25rem 1.75rem;
     font-size: var(--sm);
@@ -125,7 +125,7 @@ const mixins = {
     &:hover,
     &:focus,
     &:active {
-      background-color: var(--green-tint);
+      background-color: var(--accent-tint);
       outline: none;
     }
     &:after {
@@ -156,7 +156,7 @@ const mixins = {
         content: '▹';
         position: absolute;
         left: 0;
-        color: var(--green);
+        color: var(--accent);
       }
     }
   `,

--- a/src/styles/variables.js
+++ b/src/styles/variables.js
@@ -5,17 +5,13 @@ const variables = css`
   :root {
     --main: ${config.colors.main};
     --complementary: ${config.colors.complementary};
+    --dark-complementary: #081507;
     --accent: ${config.colors.accent};
-    --highlight: ${config.colors.highlight};
-    --navy: #0a192f;
-    --light-navy: #112240;
-    --lightest-navy: #233554;
-    --navy-shadow: rgba(2, 12, 27, 0.7);
-    --dark-slate: #495670;
-    --slate: #8892b0;
-    --light-slate: #a8b2d1;
-    --light-text: #f6fcf6;
     --accent-tint: rgba(135,214,127, 0.1);
+    --accent-dark: rgba(70,196,70, 0.7);
+    --highlight: ${config.colors.highlight};
+    --text-light: #f6fcf6;
+    --shadow-main: rgba(2, 12, 27, 0.7);
     --font-accent: 'Libre Baskerville', 'San Francisco', -apple-system, system-ui,
       sans-serif;
     --font-main: 'Work Sans', 'Roboto', monospace;

--- a/src/styles/variables.js
+++ b/src/styles/variables.js
@@ -14,10 +14,8 @@ const variables = css`
     --dark-slate: #495670;
     --slate: #8892b0;
     --light-slate: #a8b2d1;
-    --lightest-slate: #ccd6f6;
-    --white: #e6f1ff;
-    --green: #64ffda;
-    --green-tint: rgba(100, 255, 218, 0.1);
+    --light-text: #f6fcf6;
+    --accent-tint: rgba(135,214,127, 0.1);
     --font-accent: 'Libre Baskerville', 'San Francisco', -apple-system, system-ui,
       sans-serif;
     --font-main: 'Work Sans', 'Roboto', monospace;

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -28,7 +28,7 @@ const StyledPostContent = styled.div`
   p {
     margin: 1em 0;
     line-height: 1.5;
-    color: var(--light-slate);
+    color: var(--text-light);
   }
 
   a {
@@ -36,8 +36,8 @@ const StyledPostContent = styled.div`
   }
 
   code {
-    background-color: var(--lightest-navy);
-    color: var(--light-text);
+    background-color: var(--accent-tint);
+    color: var(--text-light);
     border-radius: var(--border-radius);
     font-size: var(--sm);
     padding: 0.2em 0.4em;

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -37,7 +37,7 @@ const StyledPostContent = styled.div`
 
   code {
     background-color: var(--lightest-navy);
-    color: var(--lightest-slate);
+    color: var(--light-text);
     border-radius: var(--border-radius);
     font-size: var(--sm);
     padding: 0.2em 0.4em;

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -30,11 +30,11 @@ const StyledTagsContainer = styled.main`
         font-size: inherit;
         margin: 0;
         a {
-          color: var(--light-slate);
+          color: var(--text-light);
         }
       }
       .subtitle {
-        color: var(--slate);
+        color: var(--text-light);
         font-size: var(--sm);
 
         .tag {


### PR DESCRIPTION
### What
Users see the "posts" section differently.

### Why
UX. To make it "pretty"

### How
- apply a different set of css rules to the section;
- 
<img width="1384" alt="Screenshot 2023-01-09 at 15 09 58" src="https://user-images.githubusercontent.com/42477973/211305068-89d4e9c4-d9d1-4955-9059-3b1f93f7deb7.png">
