### PR TITLE
feat(featured): alternate rows

### DIFF
--- a/src/components/sections/featured.js
+++ b/src/components/sections/featured.js
@@ -22,6 +22,9 @@ const StyledProject = styled.li`
   grid-gap: 24px;
   grid-template-columns: 2fr 3fr;
   align-items: center;
+  &:nth-child(2) {
+    direction: rtl;
+  }
   @media (max-width: 768px) {
     ${({ theme }) => theme.mixins.boxShadow};
   }


### PR DESCRIPTION
### What
Users see the odd featured projects mirroring the even ones.

<img width="1034" alt="Screenshot 2023-01-16 at 16 05 10" src="https://user-images.githubusercontent.com/42477973/212709420-cd79d783-adf4-445a-99ca-27264e48fe63.png">


### Why
UX. "pretty" reasons

### How
- add direction to second child (since there would be only 3 featured projects)